### PR TITLE
Added support of TypeScript React (tsx)

### DIFF
--- a/lib/rules/bem-no-foreign-element.js
+++ b/lib/rules/bem-no-foreign-element.js
@@ -22,7 +22,7 @@ module.exports = function(context) {
         if (!filename) {
             return null;
         }
-        var match = filename.match(/(\w+)\.react\.js$/i);
+        var match = filename.match(/(\w+)\.react\.(j|t)sx?$/i);
         if (!match) {
             return null;
         }


### PR DESCRIPTION
Currently, _*.react.tsx_ files do not get reported on `bem-no-foreign-element` ESLint rule.